### PR TITLE
feat: add options as http get parameters

### DIFF
--- a/api/html.ts
+++ b/api/html.ts
@@ -4,11 +4,26 @@ import { MissingIdError } from '../_errors/missing-id';
 
 export default async (request: NowRequest, response: NowResponse): Promise<void | NowResponse> => {
   try {
-    const { id } = request.query;
+    const {
+      id,
+      bodyContentOnly,
+      excludeCSS,
+      excludeHeaderFromBody,
+      excludeMetadata,
+      excludeScripts,
+      excludeTitleFromHead,
+    } = request.query;
     if (!id) throw new MissingIdError();
 
     const url = `https://notion.so/${id}`;
-    const content = await NotionPageToHtml.convert(url);
+    const content = await NotionPageToHtml.convert(url, {
+      bodyContentOnly: bodyContentOnly === 'true',
+      excludeCSS: excludeCSS === 'true',
+      excludeHeaderFromBody: excludeHeaderFromBody === 'true',
+      excludeMetadata: excludeMetadata === 'true',
+      excludeScripts: excludeScripts === 'true',
+      excludeTitleFromHead: excludeTitleFromHead === 'true',
+    });
     const { html } = content;
 
     response.setHeader('Content-Type', 'text/html');


### PR DESCRIPTION
This PR adds http get parameters for the /html endpoint.
Fixes #5 

Example:
https://notion-page-to-html-api-five.vercel.app/html?id=4d64bbc0634d4758befa85c5a3a6c22f&bodyContentOnly=true

